### PR TITLE
add show and config commands for Tx Error Monitor

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4599,6 +4599,82 @@ def disable_use_link_local_only(ctx, interface_name):
     interface_dict = db.get_table(interface_type)
     set_ipv6_link_local_only_on_interface(db, interface_dict, interface_type, interface_name, "disable")
 
+@interface.group()
+@click.pass_context
+def txerrmon_threshold(ctx):
+    """TX Err Monitor threshold subgroup"""
+    pass
+
+#
+# 'txerrmon_threshold' subcommand
+#
+
+@txerrmon_threshold.command()
+@click.pass_context
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('interface_threshold', metavar='<interface_threshold>', required=True)
+def set(ctx, interface_name, interface_threshold):
+    """Set interface TX Err Monitor threshold"""
+    # Get the config_db connector
+    config_db = ctx.obj['config_db']
+
+    interface_alias = interface_name
+    if clicommon.get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(config_db, interface_name)
+        if interface_name is None:
+            ctx.fail("Error: interface name derived from alias {} is None!".format(interface_alias))
+
+    if not interface_name_is_valid(config_db, interface_name):
+        ctx.fail("Error: Interface {} is invalid".format(interface_alias))
+
+    log.log_info("'interface txerrmon threshold {} {}' executing...".format(interface_name, interface_threshold))
+
+    config_db.set_entry("TX_ERR_MON", interface_name, {"tx_err_mon_orch_threshold":interface_threshold})
+
+@txerrmon_threshold.command()
+@click.pass_context
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+def delete(ctx, interface_name):
+    """Delete interface TX Err Monitor threshold"""
+    # Get the config_db connector
+    config_db = ctx.obj['config_db']
+
+    interface_alias = interface_name
+    if clicommon.get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(config_db, interface_name)
+        if interface_name is None:
+            ctx.fail("interface name derived from alias {} is None!".format(interface_alias))
+        
+    log.log_info("'interface txerrmon threshold {}' executing...".format(interface_name))
+    
+    if config_db.get_entry("TX_ERR_MON", interface_name):
+        config_db.set_entry("TX_ERR_MON", interface_name, None)
+    else:
+        ctx.fail("Error: TX Error monitoring for interface {} wasn't configured!".format(interface_name))            
+
+@interface.group()
+@click.pass_context
+def txerrmon_polling_period(ctx):
+    """TX Err Monitor polling period subgroup"""
+    pass
+
+#
+# 'txerrmon_polling_period' subcommand
+#
+
+@txerrmon_polling_period.command()
+@click.pass_context
+@click.argument('polling_period', metavar='<polling_period>', required=True, type=click.IntRange(1,600))
+def set(ctx, polling_period):
+    """Set interface txerrmon threshold"""
+    # Get the config_db connector
+    config_db = ctx.obj['config_db']
+
+    log.log_info("'interface txerrmon polling period {}' executing...".format(polling_period))
+
+    config_db.set_entry("TX_ERR_MON", "POLLING_PERIOD", {"tx_err_mon_orch_polling_period":polling_period})
+
+
 #
 # 'vrf' group ('config vrf ...')
 #


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
added show command for Tx Error Monitor
added config commands for Tx Error Monitor:
set threshold per interface
set polling period
#### How I did it
added show command to show/main.py
added config commands to config/main.py
#### How to verify it
configured 2 ports on the switch to monitor the thresholds
for the sake of testing it, I changed the monitored counter in the code to SAI_PORT_STAT_ETHER_RX_OVERSIZE_PKTS.
configured IP addresses for both switch's ports and server's ports.
changed server port MTU to 9500
sent ping packets with size of 9400 bytes toward the switch monitored port.
in normal rate and default threshold and polling period (10 and 10 seconds) - port stays OK, not set to ERROR since rate is too low.
when sent 10x times higher packet rate, port became ERROR, until end of transmission + polling period interval, then changed to OK again.
used this command to test it:
ping 192.168.63.1 -n -i 0.1 -s 9400
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

