### PR TITLE
fix radius error on unicode name error due to python3

### DIFF
--- a/config/aaa.py
+++ b/config/aaa.py
@@ -405,8 +405,8 @@ def sourceip(ctx, src_ip):
         click.echo('Invalid ip address')
         return
 
-    v6_invalid_list = [ipaddress.IPv6Address(unicode('0::0')), ipaddress.IPv6Address(unicode('0::1'))]
-    net = ipaddress.ip_network(unicode(src_ip), strict=False)
+    v6_invalid_list = [ipaddress.IPv6Address('0::0'), ipaddress.IPv6Address('0::1')]
+    net = ipaddress.ip_network(src_ip, strict=False)
     if (net.version == 4):
         if src_ip == "0.0.0.0":
             click.echo('enter non-zero ip address')
@@ -446,8 +446,8 @@ def nasip(ctx, nas_ip):
         click.echo('Invalid ip address')
         return
 
-    v6_invalid_list = [ipaddress.IPv6Address(unicode('0::0')), ipaddress.IPv6Address(unicode('0::1'))]
-    net = ipaddress.ip_network(unicode(nas_ip), strict=False)
+    v6_invalid_list = [ipaddress.IPv6Address('0::0'), ipaddress.IPv6Address('0::1')]
+    net = ipaddress.ip_network(nas_ip, strict=False)
     if (net.version == 4):
         if nas_ip == "0.0.0.0":
             click.echo('enter non-zero ip address')

--- a/tests/radius_test.py
+++ b/tests/radius_test.py
@@ -52,6 +52,16 @@ RADIUS global passkey <EMPTY_STRING> (default)
 
 """
 
+show_radius_global_nasip_source_ip_output="""\
+RADIUS global auth_type pap (default)
+RADIUS global retransmit 3 (default)
+RADIUS global timeout 5 (default)
+RADIUS global passkey <EMPTY_STRING> (default)
+RADIUS global nas_ip 1.1.1.1
+RADIUS global src_ip 2000::1
+
+"""
+
 config_radius_empty_output="""\
 """
 
@@ -217,3 +227,43 @@ class TestRadius(object):
                                ["delete", "10.10.10.x"])
         print(result.output)
         assert "Invalid ConfigDB. Error" in result.output
+
+    def test_config_radius_nasip_sourceip(self, get_cmd_module):
+        (config, show) = get_cmd_module
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb.delete_table("RADIUS")
+        db.cfgdb.delete_table("RADIUS_SERVER")
+        
+        result = runner.invoke(config.config.commands["radius"],\
+                               ["nasip", "1.1.1.1"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+        result = runner.invoke(config.config.commands["radius"],\
+                               ["sourceip", "2000::1"])
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+
+        result = runner.invoke(show.cli.commands["radius"], [])
+        print(result.exit_code)
+        print(result.output)
+        assert result.output == show_radius_default_output
+
+        db.cfgdb.mod_entry("RADIUS", "global", \
+            {'auth_type' : 'pap (default)', \
+             'retransmit': '3 (default)', \
+             'timeout'   : '5 (default)', \
+             'passkey'   : '<EMPTY_STRING> (default)', \
+             'nas_ip'    : '1.1.1.1', \
+             'src_ip'    : '2000::1', \
+            } \
+        )
+
+        result = runner.invoke(show.cli.commands["radius"], [], obj=db)
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        assert result.output == show_radius_global_nasip_source_ip_output


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
fix radius command python config file for commands that fails with tracebacks due to NameError: name 'unicode' is not define

#### How I did it
delete any unicode from python config file

#### How to verify it
run the two radius commands:
```
config radius nasip 1.1.1.1
config radius sourceip 2000::1
```
and check show radius output
```
show radius
```

#### Previous command output (if the output of a command-line utility has changed)
```
root@qa-eth-vt03-1-4600ca1:/home/admin# config radius nasip 1.1.1.1
Traceback (most recent call last):
File "/usr/local/bin/config", line 8, in
sys.exit(config())
File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 764, in call
return self.main(*args, **kwargs)
File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 717, in main
rv = self.invoke(ctx)
File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1137, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 956, in invoke
return ctx.invoke(self.callback, **ctx.params)
File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 555, in invoke
return callback(*args, **kwargs)
File "/usr/local/lib/python3.9/dist-packages/click/decorators.py", line 17, in new_func
return f(get_current_context(), *args, **kwargs)
File "/usr/local/lib/python3.9/dist-packages/config/aaa.py", line 448, in nasip
v6_invalid_list = [ipaddress.IPv6Address(unicode('0::0')), ipaddress.IPv6Address(unicode('0::1'))]
NameError: name 'unicode' is not defined
root@qa-eth-vt03-1-4600ca1:/home/admin# config radius sourceip 2000::1
...
File "/usr/local/lib/python3.9/dist-packages/click/decorators.py", line 17, in new_func
return f(get_current_context(), *args, **kwargs)
File "/usr/local/lib/python3.9/dist-packages/config/aaa.py", line 407, in sourceip
v6_invalid_list = [ipaddress.IPv6Address(unicode('0::0')), ipaddress.IPv6Address(unicode('0::1'))]
NameError: name 'unicode' is not defined
root@qa-eth-vt03-1-4600ca1:/home/admin#
```

#### New command output (if the output of a command-line utility has changed)
```
root@r-panther-13:/home/admin# config radius nasip 1.1.1.1
root@r-panther-13:/home/admin# config radius sourceip 1.1.1.1
root@r-panther-13:/home/admin# show radius 
RADIUS global auth_type pap (default)
RADIUS global retransmit 3 (default)
RADIUS global timeout 5 (default)
RADIUS global passkey <EMPTY_STRING> (default)
RADIUS global nas_ip 1.1.1.1
RADIUS global src_ip 1.1.1.1

root@r-panther-13:/home/admin# 
```
