### PR TITLE
update watchdogutil to call Platform with set logging level on the fly with value False

### DIFF
--- a/watchdogutil/main.py
+++ b/watchdogutil/main.py
@@ -35,7 +35,7 @@ log = logger.Logger(SYSLOG_IDENTIFIER)
 def load_platform_watchdog():
     global platform_watchdog
 
-    platform = sonic_platform.platform.Platform()
+    platform = sonic_platform.platform.Platform(False)
 
     chassis = platform.get_chassis()
     if not chassis:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
prevent runtime error with traceback in warm-reboot due to new python logger functionality allowing to change
the logging level on the fly

#### How I did it
call Platform with this set on the fly flag set to False, which will pass to chassis and call the logger with this flag
set to False when watchdogutil is calling it

#### How to verify it
run warm-reboot and verify runtime error and traceback doesn't happen

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

